### PR TITLE
udpate observation dto & grid's extractor

### DIFF
--- a/src/app/features/auth/models.ts
+++ b/src/app/features/auth/models.ts
@@ -34,6 +34,16 @@ export interface UserInfo {
   id: string;
 }
 
+export interface PersonInfo {
+  id: string;
+  email?: string;
+  name: string;
+  phone?: string;
+  altPhone?: string;
+  address?: string;
+  code?: string;
+}
+
 export interface IAuthInfo {
   user: UserInfo;
   permissions: Ability;

--- a/src/app/features/auth/models.ts
+++ b/src/app/features/auth/models.ts
@@ -34,16 +34,6 @@ export interface UserInfo {
   id: string;
 }
 
-export interface PersonInfo {
-  id: string;
-  email?: string;
-  name: string;
-  phone?: string;
-  altPhone?: string;
-  address?: string;
-  code?: string;
-}
-
 export interface IAuthInfo {
   user: UserInfo;
   permissions: Ability;

--- a/src/app/features/common/models.ts
+++ b/src/app/features/common/models.ts
@@ -1,0 +1,9 @@
+export interface PersonInfo {
+  id: string;
+  email?: string;
+  name: string;
+  phone?: string;
+  altPhone?: string;
+  address?: string;
+  code?: string;
+}

--- a/src/app/features/observations/models.ts
+++ b/src/app/features/observations/models.ts
@@ -4,7 +4,8 @@ import {
   GridDataResponse,
   GridQuery
 } from "../../../components/table/DataGridModels";
-import { UserInfo, PersonInfo } from "../auth/models";
+import { UserInfo } from "../auth/models";
+import { PersonInfo } from "../common/models";
 
 export enum VerificationStatus {
   pending = "pending",

--- a/src/app/features/observations/models.ts
+++ b/src/app/features/observations/models.ts
@@ -4,7 +4,7 @@ import {
   GridDataResponse,
   GridQuery
 } from "../../../components/table/DataGridModels";
-import { UserInfo } from "../auth/models";
+import { UserInfo, PersonInfo } from "../auth/models";
 
 export enum VerificationStatus {
   pending = "pending",
@@ -30,7 +30,9 @@ export interface ObservationData {
   date: string;
   direction: number; // deg
   distance: number; // km
-  finder: UserInfo;
+  finder: UserInfo | null;
+  offlineFinder: PersonInfo | null;
+  offlineFinderNote: string | null;
   elapsedTime: number; // days
   remarks: string;
   sexMentioned: DescriptedField;

--- a/src/utils/grid/commonGridColumns.tsx
+++ b/src/utils/grid/commonGridColumns.tsx
@@ -10,6 +10,26 @@ import { IndexCell } from "./cellRenderers/IndexCell";
 import { VerificationCell } from "./cellRenderers/VerificationCell";
 import { GridColumn } from "./GridColumn";
 
+const finderHelper = ({
+  finder,
+  offlineFinder,
+  offlineFinderNote
+}: ObservationData): string => {
+  if (finder) {
+    return (
+      [finder.firstName || "", finder.lastName || ""].join(" ").trim() ||
+      "Uknown"
+    );
+  }
+  if (offlineFinder) {
+    return offlineFinder.name || "";
+  }
+  if (offlineFinderNote) {
+    return `${offlineFinderNote}` || "";
+  }
+  return "";
+};
+
 export const COMMON_GRID_COLUMNS: {
   [key in GridColumn]: DataGridCol<ObservationData>;
 } = {
@@ -173,11 +193,7 @@ export const COMMON_GRID_COLUMNS: {
   finder: {
     name: GridColumn.finder,
     title: labels.finder,
-    getCellValue: r => (
-      <>
-        {r.finder.firstName} {r.finder.lastName}
-      </>
-    ),
+    getCellValue: r => <>{finderHelper(r)}</>,
     filter: {
       // TODO type DataGridFilter to allow any or generic value as it actually does, instead of restricting it
       getLabel: ({ value }: any) =>

--- a/src/utils/grid/commonGridColumns.tsx
+++ b/src/utils/grid/commonGridColumns.tsx
@@ -15,19 +15,17 @@ const finderHelper = ({
   offlineFinder,
   offlineFinderNote
 }: ObservationData): string => {
+  let value;
   if (finder) {
-    return (
-      [finder.firstName || "", finder.lastName || ""].join(" ").trim() ||
-      "Uknown"
-    );
+    value = [finder.firstName, finder.lastName].join(" ").trim();
   }
   if (offlineFinder) {
-    return offlineFinder.name || "";
+    value = offlineFinder.name;
   }
   if (offlineFinderNote) {
-    return `${offlineFinderNote}` || "";
+    value = offlineFinderNote;
   }
-  return "";
+  return value || "Uknown";
 };
 
 export const COMMON_GRID_COLUMNS: {


### PR DESCRIPTION
### What does this PR do?
Adjusts Observation to new shape which now supports two additional fields `offlineFinder` & `offlineFinderNote` in addition to `finder`. Only one of these three can be filled and all other will be `null`


### How should I test this?

Observation endpoint should work without `TypeError: "e.finder is null"`

### Link to branch and/or PR's related

- https://github.com/abahachuk/ptushki-backend/pull/32 PR which implies changes mentioned above

### Type of change

- [ ] Adds new features.
- [ ] Changes existing functionality.
- [ ] Deprecates features.
- [ ] Removes features.
- [x] Fixes any bug.
- [ ] Other: security, build process, infrastructure, tests, docs, etc.
